### PR TITLE
Improve logging outputs and progress display

### DIFF
--- a/logger/extras/dependency.py
+++ b/logger/extras/dependency.py
@@ -41,7 +41,7 @@ class DependencyManager:
         self._last_update = now
         return info
 
-def logger_log_environment(self: Logger, level: str = 'INFO') -> None:
+def logger_log_environment(self: Logger, level: str = 'INFO', return_block: bool = False) -> str | None:
     info = self._dep_manager.get_environment_info()
     log_method = getattr(self, level.lower())
     linhas = [
@@ -54,4 +54,6 @@ def logger_log_environment(self: Logger, level: str = 'INFO') -> None:
         if pkg in info['packages']:
             linhas.append(f"  - {pkg}: {info['packages'][pkg]}")
     bloco = format_block("🔧 AMBIENTE", linhas)
+    if return_block:
+        return bloco
     log_method(f"\n{bloco}")

--- a/logger/handlers/__init__.py
+++ b/logger/handlers/__init__.py
@@ -1,0 +1,1 @@
+from .progress_handler import ProgressStreamHandler

--- a/logger/handlers/progress_handler.py
+++ b/logger/handlers/progress_handler.py
@@ -1,0 +1,14 @@
+import logging
+from logging import StreamHandler
+
+class ProgressStreamHandler(StreamHandler):
+    """StreamHandler que mantém a barra de progresso visível durante logs."""
+    def emit(self, record: logging.LogRecord) -> None:
+        logger = logging.getLogger(record.name)
+        pbar = getattr(logger, "_active_pbar", None)
+        if pbar and not pbar.closed:
+            pbar._clear_line()
+        super().emit(record)
+        if pbar and not pbar.closed:
+            pbar._print_progress()
+

--- a/logger/tests/test_basic.py
+++ b/logger/tests/test_basic.py
@@ -8,3 +8,4 @@ def test_start_logger(tmp_path):
     logger.info("ok")
     logger.end()
     assert os.path.exists(logger.log_path)
+    assert os.path.exists(logger.debug_log_path)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from logger import start_logger
 
 
 def main():
-    logger = start_logger("Demo", split_debug=True)
+    logger = start_logger("Demo")
     logger.start()
     logger.info("Processo iniciado")
     with logger.context("Etapa"):  # from context module via start_logger


### PR DESCRIPTION
## Summary
- persist debug logs by default and track file paths
- improve single-line progress bar handling
- horizontally combine start/end banners
- expose debug log path accessors
- update demo and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c9cf15c483339bff2af99b17ab36