### PR TITLE
Add automatic memory leak reporting

### DIFF
--- a/logger/__init__.pyi
+++ b/logger/__init__.pyi
@@ -81,7 +81,15 @@ class StructuredLogger(Logger):
         """Armazena um snapshot de memória para comparação futura."""
         ...
 
-    def check_memory_leak(self, level: str = "WARNING") -> None:
+    def check_memory_leak(
+        self,
+        level: str = "WARNING",
+        return_block: bool = False,
+        *,
+        show_all: bool | None = None,
+        watch: Iterable[str] | None = None,
+        mem_threshold: float | None = None,
+    ) -> str | None:
         """Verifica diferenças de uso de memória indicando possível vazamento."""
         ...
 
@@ -118,8 +126,15 @@ class StructuredLogger(Logger):
 
 
 def start_logger(
-    name: str | None = ..., log_dir: str = "Logs", console_level: str = "INFO",
-    file_level: str = "DEBUG", capture_prints: bool = True, verbose: int = 0
+    name: str | None = ...,
+    log_dir: str = "Logs",
+    console_level: str = "INFO",
+    file_level: str = "DEBUG",
+    capture_prints: bool = True,
+    verbose: int = 0,
+    *,
+    show_all_leaks: bool = False,
+    watch_objects: Iterable[str] | None = None,
 ) -> StructuredLogger:
     """Cria e devolve um Logger configurado.
 

--- a/logger/extras/__init__.pyi
+++ b/logger/extras/__init__.pyi
@@ -68,7 +68,15 @@ def logger_log_system_status(self: Logger, level: str = ..., return_block: bool 
 
 def logger_memory_snapshot(self: Logger) -> None: ...
 
-def logger_check_memory_leak(self: Logger, level: str = ...) -> None: ...
+def logger_check_memory_leak(
+    self: Logger,
+    level: str = ...,
+    return_block: bool = ...,
+    *,
+    show_all: bool | None = ...,
+    watch: Iterable[str] | None = ...,
+    mem_threshold: float | None = ...,
+) -> str | None: ...
 
 def logger_sleep(self: Logger, duration: float, unit: str = ..., level: str = ..., message: str | None = ...) -> None: ...
 

--- a/logger/extras/logger_lifecycle.py
+++ b/logger/extras/logger_lifecycle.py
@@ -51,15 +51,18 @@ def logger_log_end(self: Logger, verbose: int = 1) -> None:
     data = now.strftime("%d/%m/%Y")
     hora = now.strftime("%H:%M:%S")
 
+    leak_block: str | None = None
     if verbose >= 2:
         self.report_metrics()  # type: ignore[attr-defined]
         self.debug("Verificando possíveis vazamentos de memória...")
-        self.check_memory_leak()  # type: ignore[attr-defined]
+    leak_block = self.check_memory_leak(return_block=True)  # type: ignore[attr-defined]
 
     blocks: list[str] = []
     if verbose >= 1:
         blocks.append(self.log_system_status(return_block=True))  # type: ignore[attr-defined]
         blocks.append(self.check_connectivity(return_block=True))  # type: ignore[attr-defined]
+    if leak_block:
+        blocks.append(leak_block)
 
     lines = [
         "PROCESSO FINALIZADO",


### PR DESCRIPTION
## Summary
- capture memory snapshot when starting the logger
- report memory leaks in the final banner
- expose return_block option for `check_memory_leak`
- test memory snapshot capture and memory leak banner
- configurable memory leak reporting

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855d6a8e77c8333bde320ad8ea230f5