### PR TITLE
Add profiling summary to final banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ logger.info("Processo iniciado")
 
 O método ``logger.end()`` é chamado automaticamente ao término do
 programa, mas pode ser invocado manualmente caso deseje encerrar o
-logger antecipadamente.
+logger antecipadamente. Ao finalizar, um banner de resumo exibe métricas
+de execução, incluindo um relatório das funções mais demoradas.
 
 Para mais exemplos consulte `main.py`.
 

--- a/logger/__init__.pyi
+++ b/logger/__init__.pyi
@@ -112,6 +112,14 @@ class StructuredLogger(Logger):
 
     def profile_cm(self, name: str | None = ...) -> ContextManager[Any]: ...
 
+    def profile_report(
+        self,
+        *,
+        limit: int = ...,
+        level: str = ...,
+        return_block: bool = ...,
+    ) -> str | None: ...
+
     # dynamically added attributes
     _screen_dir: Path
     _screen_name: str

--- a/logger/extras/logger_lifecycle.py
+++ b/logger/extras/logger_lifecycle.py
@@ -30,6 +30,7 @@ def logger_log_start(self: Logger, verbose: int = 1) -> None:
 
     if verbose >= 1:
         self.reset_metrics()  # type: ignore[attr-defined]
+        self._profiler.start()  # type: ignore[attr-defined]
         status = self.log_system_status(return_block=True)  # type: ignore[attr-defined]
         env = self.log_environment(return_block=True)  # type: ignore[attr-defined]
         conn = self.check_connectivity(return_block=True)  # type: ignore[attr-defined]
@@ -56,6 +57,9 @@ def logger_log_end(self: Logger, verbose: int = 1) -> None:
         self.report_metrics()  # type: ignore[attr-defined]
         self.debug("Verificando possíveis vazamentos de memória...")
     leak_block = self.check_memory_leak(return_block=True)  # type: ignore[attr-defined]
+    profile_block: str | None = None
+    if verbose >= 1:
+        profile_block = self.profile_report(return_block=True)  # type: ignore[attr-defined]
 
     blocks: list[str] = []
     if verbose >= 1:
@@ -63,6 +67,8 @@ def logger_log_end(self: Logger, verbose: int = 1) -> None:
         blocks.append(self.check_connectivity(return_block=True))  # type: ignore[attr-defined]
     if leak_block:
         blocks.append(leak_block)
+    if profile_block:
+        blocks.append(profile_block)
 
     lines = [
         "PROCESSO FINALIZADO",


### PR DESCRIPTION
## Summary
- start automatic profiling on logger start
- show profiling results in final banner
- expose new `profile_report` method in typing stubs
- document profiling summary in README

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855dceea1a88333bd61766599a52968