### PR TITLE
Enhance profiling in log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ logger.info("Processo iniciado")
 
 O método ``logger.end()`` é chamado automaticamente ao término do
 programa, mas pode ser invocado manualmente caso deseje encerrar o
-logger antecipadamente.
+logger antecipadamente. Ao finalizar, um banner de resumo exibe métricas.
+O detalhamento completo do profiling, com cadeia de chamadas e tempos,
+é registrado apenas nos arquivos de log.
 
 Para mais exemplos consulte `main.py`.
 

--- a/logger/__init__.pyi
+++ b/logger/__init__.pyi
@@ -112,6 +112,14 @@ class StructuredLogger(Logger):
 
     def profile_cm(self, name: str | None = ...) -> ContextManager[Any]: ...
 
+    def profile_report(
+        self,
+        *,
+        limit: int = ...,
+        level: str = ...,
+        return_block: bool = ...,
+    ) -> str | None: ...
+
     # dynamically added attributes
     _screen_dir: Path
     _screen_name: str

--- a/logger/core/context.py
+++ b/logger/core/context.py
@@ -13,6 +13,7 @@ import cProfile
 import functools
 import io
 import pstats
+from logger.extras.progress import format_block
 
 # Armazena o método original de logging antes de qualquer monkey patch
 _original_log_method = Logger._log
@@ -79,6 +80,40 @@ class Profiler:
         ps.print_stats(20)
         return s.getvalue()
 
+    def _build_chain(
+        self,
+        func: tuple[str, int, str],
+        stats: dict,
+        depth: int = 3,
+    ) -> list[tuple[str, int, str]]:
+        if depth <= 0:
+            return [func]
+        callers = stats.get(func, (0, 0, 0.0, 0.0, {}))[4]
+        if not callers:
+            return [func]
+        best = max(callers.items(), key=lambda kv: kv[1][3])[0]
+        return self._build_chain(best, stats, depth - 1) + [func]
+
+    def get_report_lines(self, limit: int = 10) -> list[str]:
+        """Linhas de profiling ordenadas por tempo acumulado em português."""
+        if not self.profiler:
+            return []
+        ps = pstats.Stats(self.profiler)
+        ps.calc_callees()
+        stats_dict: dict = getattr(ps, "stats", {})  # type: ignore[attr-defined]
+        items = []
+        for func, (cc, nc, tt, ct, callers) in stats_dict.items():
+            items.append((ct, tt, nc, func))
+        items.sort(reverse=True)
+        lines = []
+        for ct, tt, nc, func in items[:limit]:
+            chain = self._build_chain(func, stats_dict)
+            names = " → ".join(f[2] for f in chain)
+            lines.append(
+                f"{names} | chamadas: {nc} | acumulado: {ct:.3f}s | próprio: {tt:.3f}s"
+            )
+        return lines
+
 # --- Wrappers de profiling ---
 
 @contextmanager
@@ -106,6 +141,25 @@ def logger_profile(
             return func(*args, **kwargs)
     return wrapper
 
+
+def logger_profile_report(
+    self: Logger,
+    *,
+    limit: int = 10,
+    level: str = "INFO",
+    return_block: bool = False,
+) -> str | None:
+    """Gera um resumo do profiling executado com rótulos em português."""
+    self._profiler.stop()  # type: ignore[attr-defined]
+    lines = self._profiler.get_report_lines(limit)  # type: ignore[attr-defined]
+    if not lines:
+        return None
+    block = format_block("PROFILING", lines)
+    if return_block:
+        return block
+    getattr(self, level.lower())(f"\n{block}", extra={"plain": True, "file_only": True})
+    return None
+
 def _setup_context_and_profiling(logger: Logger) -> None:
     """Configura suporte a contexto e profiling na instancia do logger."""
     context_manager: ContextManager = ContextManager()
@@ -124,3 +178,4 @@ def _setup_context_and_profiling(logger: Logger) -> None:
     setattr(Logger, 'context', logger_context)
     setattr(Logger, 'profile', logger_profile)
     setattr(Logger, 'profile_cm', logger_profile_cm)
+    setattr(Logger, 'profile_report', logger_profile_report)

--- a/logger/core/logger_core.py
+++ b/logger/core/logger_core.py
@@ -16,7 +16,7 @@ from logger.formatters.custom import (
     AutomaticTracebackLogger,
     _define_custom_levels,
 )
-from logger.handlers import ProgressStreamHandler
+from logger.handlers import ProgressStreamHandler, FileOnlyFilter
 from logger.core.context import _setup_context_and_profiling
 from logger.extras import (
     _init_colorama,
@@ -152,6 +152,7 @@ def _configure_base_logger(
     ch = ProgressStreamHandler()
     ch.setLevel(console_level_value)
     ch.setFormatter(CustomFormatter(fmt=console_fmt, datefmt=datefmt, style="{"))
+    ch.addFilter(FileOnlyFilter())
     logger.addHandler(ch)
 
     # Arquivo DEBUG – sempre no formato máximo

--- a/logger/extras/logger_lifecycle.py
+++ b/logger/extras/logger_lifecycle.py
@@ -30,6 +30,7 @@ def logger_log_start(self: Logger, verbose: int = 1) -> None:
 
     if verbose >= 1:
         self.reset_metrics()  # type: ignore[attr-defined]
+        self._profiler.start()  # type: ignore[attr-defined]
         status = self.log_system_status(return_block=True)  # type: ignore[attr-defined]
         env = self.log_environment(return_block=True)  # type: ignore[attr-defined]
         conn = self.check_connectivity(return_block=True)  # type: ignore[attr-defined]
@@ -56,6 +57,12 @@ def logger_log_end(self: Logger, verbose: int = 1) -> None:
         self.report_metrics()  # type: ignore[attr-defined]
         self.debug("Verificando possíveis vazamentos de memória...")
     leak_block = self.check_memory_leak(return_block=True)  # type: ignore[attr-defined]
+    profile_summary: str | None = None
+    if verbose >= 1:
+        self.profile_report()  # type: ignore[attr-defined]
+        summary_lines = self._profiler.get_report_lines(3)  # type: ignore[attr-defined]
+        if summary_lines:
+            profile_summary = format_block("PROFILING", summary_lines[:1])
 
     blocks: list[str] = []
     if verbose >= 1:
@@ -63,6 +70,8 @@ def logger_log_end(self: Logger, verbose: int = 1) -> None:
         blocks.append(self.check_connectivity(return_block=True))  # type: ignore[attr-defined]
     if leak_block:
         blocks.append(leak_block)
+    if profile_summary:
+        blocks.append(profile_summary)
 
     lines = [
         "PROCESSO FINALIZADO",

--- a/logger/handlers/__init__.py
+++ b/logger/handlers/__init__.py
@@ -1,3 +1,12 @@
+import logging
 from .progress_handler import ProgressStreamHandler
 
-__all__ = ["ProgressStreamHandler"]
+
+class FileOnlyFilter(logging.Filter):
+    """Filter that skips records marked as ``file_only`` on console."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        """Return ``False`` for messages flagged as file only."""
+        return not getattr(record, "file_only", False)
+
+__all__ = ["ProgressStreamHandler", "FileOnlyFilter"]


### PR DESCRIPTION
## Summary
- show profiling summary with Portuguese labels and call chains
- log full profiling report only to files via new FileOnlyFilter
- display a short profiling summary in the end banner

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855dceea1a88333bd61766599a52968