### PR TITLE
Add Sphinx docs and deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt sphinx
+      - run: make -C docs html
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/build/html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -49,3 +49,18 @@ ruff check .
 mypy .
 pytest -q
 ```
+
+## Documentação
+
+A documentação completa é gerada com **Sphinx** e publicada automaticamente no
+GitHub Pages. Para gerar a versão local instale o Sphinx e execute:
+
+```bash
+pip install sphinx
+```
+
+```bash
+make -C docs html
+```
+
+Os arquivos HTML serão gerados em `docs/build/html`.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api/logger.cli.rst
+++ b/docs/source/api/logger.cli.rst
@@ -1,0 +1,10 @@
+logger.cli package
+==================
+
+Module contents
+---------------
+
+.. automodule:: logger.cli
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.core.rst
+++ b/docs/source/api/logger.core.rst
@@ -1,0 +1,29 @@
+logger.core package
+===================
+
+Submodules
+----------
+
+logger.core.context module
+--------------------------
+
+.. automodule:: logger.core.context
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.core.logger\_core module
+-------------------------------
+
+.. automodule:: logger.core.logger_core
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: logger.core
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.extras.base_funcs.rst
+++ b/docs/source/api/logger.extras.base_funcs.rst
@@ -1,0 +1,53 @@
+logger.extras.base\_funcs package
+=================================
+
+Submodules
+----------
+
+logger.extras.base\_funcs.cleanup module
+----------------------------------------
+
+.. automodule:: logger.extras.base_funcs.cleanup
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.base\_funcs.debug\_path module
+--------------------------------------------
+
+.. automodule:: logger.extras.base_funcs.debug_path
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.base\_funcs.path module
+-------------------------------------
+
+.. automodule:: logger.extras.base_funcs.path
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.base\_funcs.pause module
+--------------------------------------
+
+.. automodule:: logger.extras.base_funcs.pause
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.base\_funcs.screen module
+---------------------------------------
+
+.. automodule:: logger.extras.base_funcs.screen
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: logger.extras.base_funcs
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.extras.rst
+++ b/docs/source/api/logger.extras.rst
@@ -1,0 +1,85 @@
+logger.extras package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   logger.extras.base_funcs
+
+Submodules
+----------
+
+logger.extras.dependency module
+-------------------------------
+
+.. automodule:: logger.extras.dependency
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.helpers module
+----------------------------
+
+.. automodule:: logger.extras.helpers
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.logger\_lifecycle module
+--------------------------------------
+
+.. automodule:: logger.extras.logger_lifecycle
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.metrics module
+----------------------------
+
+.. automodule:: logger.extras.metrics
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.monitoring module
+-------------------------------
+
+.. automodule:: logger.extras.monitoring
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.network module
+----------------------------
+
+.. automodule:: logger.extras.network
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.printing module
+-----------------------------
+
+.. automodule:: logger.extras.printing
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.extras.progress module
+-----------------------------
+
+.. automodule:: logger.extras.progress
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: logger.extras
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.formatters.rst
+++ b/docs/source/api/logger.formatters.rst
@@ -1,0 +1,21 @@
+logger.formatters package
+=========================
+
+Submodules
+----------
+
+logger.formatters.custom module
+-------------------------------
+
+.. automodule:: logger.formatters.custom
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: logger.formatters
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.handlers.rst
+++ b/docs/source/api/logger.handlers.rst
@@ -1,0 +1,21 @@
+logger.handlers package
+=======================
+
+Submodules
+----------
+
+logger.handlers.progress\_handler module
+----------------------------------------
+
+.. automodule:: logger.handlers.progress_handler
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: logger.handlers
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.rst
+++ b/docs/source/api/logger.rst
@@ -1,0 +1,23 @@
+logger package
+==============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   logger.cli
+   logger.core
+   logger.extras
+   logger.formatters
+   logger.handlers
+   logger.tests
+
+Module contents
+---------------
+
+.. automodule:: logger
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/logger.tests.rst
+++ b/docs/source/api/logger.tests.rst
@@ -1,0 +1,29 @@
+logger.tests package
+====================
+
+Submodules
+----------
+
+logger.tests.test\_basic module
+-------------------------------
+
+.. automodule:: logger.tests.test_basic
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+logger.tests.test\_extras module
+--------------------------------
+
+.. automodule:: logger.tests.test_extras
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: logger.tests
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,0 +1,7 @@
+logger
+======
+
+.. toctree::
+   :maxdepth: 4
+
+   logger

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,38 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Logger'
+copyright = '2025, Elian Abrao'
+author = 'Elian Abrao'
+
+version = '0.1.0'
+release = '0.1.0'
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,11 @@
+Logger documentation
+====================
+
+Bem-vindo à documentação do projeto ``Logger``.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Conteúdo
+
+   usage
+   api/modules

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,11 @@
+Uso Básico
+==========
+
+Para iniciar um logger configurado execute::
+
+    from logger import start_logger
+    
+    logger = start_logger("Demo")
+    logger.info("Processo iniciado")
+
+Para exemplos completos consulte :mod:`main`.


### PR DESCRIPTION
## Summary
- create docs/ with Sphinx configuration
- generate API docs for modules
- add GitHub Actions workflow to publish docs on Pages
- document how to build docs locally

## Testing
- `pytest -q`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_6856421c89188333a82cc20ec4627f2a