### PR TITLE
Add CI workflow and publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -e .
+          python -m pip install -r requirements.txt
+          python -m pip install ruff mypy pytest pytest-cov
+      - name: Ruff
+        run: ruff check .
+      - name: Mypy
+        run: mypy .
+      - name: Pytest
+        run: pytest --cov=logger

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Logger
 
+![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)
+
 Biblioteca de logging estruturado. Veja `main.py` para um exemplo completo.
 
 ## Instalação


### PR DESCRIPTION
## Summary
- add CI workflow running ruff, mypy, and pytest with coverage
- add workflow to publish to PyPI when tagging a release
- show CI badge in README

## Testing
- `ruff check .`
- `mypy .`
- `pytest --cov=logger`

------
https://chatgpt.com/codex/tasks/task_e_6856421ae7ac83338f0a43efec8e92a7