### PR TITLE
Add developer documentation in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 ![CI](https://github.com/Elian-Abrao/Logger/actions/workflows/ci.yml/badge.svg)
 
-Biblioteca de logging estruturado. Veja `main.py` para um exemplo completo.
+Biblioteca de logging estruturado com barra de progresso, métricas e monitoramento.
+
+## Sumário
+
+- [Instalação](#instala%c3%a7%c3%a3o)
+- [Uso básico](#uso-b%c3%a1sico)
+- [Testes e qualidade](#testes-e-qualidade)
+- [Documentação](#documenta%c3%a7%c3%a3o)
 
 ## Instalação
-
-Com o Python instalado, instale o pacote e suas dependências em modo de
-desenvolvimento:
 
 ```bash
 pip install -e .[dev]
@@ -15,44 +19,18 @@ pip install -e .[dev]
 
 ## Uso básico
 
-Crie uma instância do logger chamando `start_logger`:
-
 ```python
 from logger import start_logger
 
 logger = start_logger("Demo")
 logger.info("Processo iniciado")
+for i in logger.progress(range(5), desc="Trabalhando"):
+    logger.debug(f"Passo {i}")
 ```
 
-O método ``logger.end()`` é chamado automaticamente ao término do programa, mas pode ser invocado manualmente caso deseje encerrar o logger antecipadamente. Ao finalizar, um banner de resumo exibe métricas.
-O detalhamento completo do profiling, com cadeia de chamadas e tempos, é registrado apenas nos arquivos de log.
+`logger.end()` é chamado automaticamente no encerramento do programa, exibindo um banner resumo.
 
-
-Para mais exemplos consulte `main.py`.
-
-## Testes e qualidade de código
-
-Instale as dependências do projeto com:
-
-```bash
-pip install -e .[dev]
-```
-
-Para reproduzir exatamente o ambiente utilizado, instale a partir do arquivo
-`requirements.lock` gerado via `pip freeze`:
-
-```bash
-pip install -r requirements.lock
-```
-
-Sempre que atualizar as dependências, execute:
-
-```bash
-pip freeze > requirements.lock
-```
-para sincronizar o arquivo de lock.
-
-Com as dependências instaladas, execute as ferramentas de verificação:
+## Testes e qualidade
 
 ```bash
 ruff check .
@@ -64,21 +42,8 @@ safety check -r requirements.lock || true
 
 ## Documentação
 
-A documentação completa é gerada com **Sphinx** e publicada automaticamente no
-GitHub Pages. Para gerar a versão local instale o Sphinx e execute:
-
-```bash
-pip install sphinx
-```
+Os guias completos estão em [docs/md/index.md](docs/md/index.md). Para gerar o site Sphinx localmente:
 
 ```bash
 make -C docs html
 ```
-
-Para gerar os pacotes de distribuição execute:
-
-```bash
-python -m build
-```
-
-Os arquivos HTML serão gerados em `docs/build/html`.

--- a/docs/md/advanced_config.md
+++ b/docs/md/advanced_config.md
@@ -1,0 +1,18 @@
+# Configurações Avançadas
+
+| Variável | Default | Descrição |
+|----------|---------|-----------|
+| `LOG_DIR` | `Logs` | Diretório base para armazenamento dos arquivos de log |
+| `LOGGER_VERBOSE` | `0` | Nível de verbosidade extra nos arquivos |
+
+### Linha de comando
+
+Ao instalar o pacote é criado o script `logger-demo` que executa `main.py`. Exemplo:
+
+```bash
+logger-demo
+```
+
+### Arquivo de Configuração
+
+Opcionalmente é possível criar um arquivo YAML para centralizar opções e carregar com `pyyaml` antes de chamar `start_logger`.

--- a/docs/md/api_reference.md
+++ b/docs/md/api_reference.md
@@ -1,0 +1,30 @@
+# Referência de API
+
+## `start_logger`
+
+```python
+def start_logger(
+    name: str | None = None,
+    log_dir: str = "Logs",
+    console_level: str = "INFO",
+    file_level: str = "DEBUG",
+    capture_prints: bool = True,
+    verbose: int = 0,
+    *,
+    show_all_leaks: bool = False,
+    watch_objects: Iterable[str] | None = None,
+) -> logging.Logger:
+    ...
+```
+
+Cria e retorna uma instância de `Logger` já configurada. Os parâmetros permitem ajustar níveis de log, diretório de saída e verbosidade.
+
+### Principais Métodos do Logger
+
+- `progress(iterable, desc="", total=None)` → barra de progresso integrada.
+- `timer(name="Tarefa")` → context manager para medir duração.
+- `sleep(duration, unit="s")` → pausa com log.
+- `log_environment()` → registra informações do ambiente.
+- `check_connectivity(urls=None)` → testa conexão de rede.
+- `log_system_status()` → CPU e memória atuais.
+- `profile(func)` → decorador de profiling.

--- a/docs/md/architecture.md
+++ b/docs/md/architecture.md
@@ -1,0 +1,27 @@
+# Visão de Arquitetura
+
+```mermaid
+graph TD
+    A[Aplicação Usuário] --> B[start_logger]
+    B --> C[Logger Core]
+    C --> D[Extras]
+    C --> E[Handlers]
+    D --> F[Metrics / Monitoring / Network]
+    E --> G[Console]
+    E --> H[Arquivos de Log]
+```
+
+O diagrama acima mostra o fluxo principal: a aplicação inicializa o logger com `start_logger`, que configura o núcleo e adiciona funcionalidades extras. As mensagens são enviadas para o console e para arquivos de log.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Logger
+    App->>Logger: start_logger("Demo")
+    Logger-->>App: objeto Logger
+    App->>Logger: info("Processo iniciado")
+    App->>Logger: progress(range(5))
+    App->>Logger: end()
+```
+
+Nesta sequência, a aplicação cria o logger, registra mensagens e encerra a execução.

--- a/docs/md/changelog.md
+++ b/docs/md/changelog.md
@@ -1,0 +1,8 @@
+# Histórico de Versões
+
+## [0.1.0] - 2025-01-01
+- Primeira publicação do pacote com suporte a:
+  - Logs coloridos e níveis personalizados
+  - Barra de progresso integrada
+  - Métricas e monitoramento de sistema
+  - Verificação de conectividade

--- a/docs/md/developer.md
+++ b/docs/md/developer.md
@@ -1,0 +1,31 @@
+# Manual do Desenvolvedor
+
+## Estrutura de Pastas
+
+```
+logger/
+  core/        # Configuração principal e contexto
+  extras/      # Funcionalidades adicionais (metrics, network, monitoring)
+  formatters/  # Formatadores de log coloridos
+  handlers/    # Handlers customizados
+  tests/       # Suite de testes com pytest
+```
+
+A função principal é `start_logger` em `logger.core.logger_core`. Os módulos em `extras` estendem o logger com métricas, monitoramento de rede, captura de prints, entre outros.
+
+## Convenções de Código
+
+- Estilo formatado com **ruff** e **black**.
+- Docstrings em português.
+- Utilização opcional de emojis nas mensagens 😄.
+- Progressos impressos via `LoggerProgressBar`.
+
+## Versionamento
+
+O projeto utiliza o padrão **SemVer**. O branch principal é `main` e as contribuições são feitas via Pull Request.
+
+## Contribuição
+
+1. Crie um fork e branch para sua feature.
+2. Execute os testes: `pytest --cov=logger`.
+3. Abra o PR seguindo o template do repositório.

--- a/docs/md/examples.md
+++ b/docs/md/examples.md
@@ -1,0 +1,17 @@
+# Casos de Uso e Exemplos
+
+## Monitoramento de Sistema
+
+```python
+from logger import start_logger
+
+logger = start_logger("Monitor")
+logger.log_system_status()
+logger.end()
+```
+
+## Verificação de Conectividade
+
+```python
+logger.check_connectivity(["https://www.google.com", "https://pypi.org"])
+```

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -1,0 +1,19 @@
+# Documentação do Logger
+
+Bem-vindo à documentação em Markdown da biblioteca **Logger**. Este conjunto de guias tem como objetivo auxiliar desenvolvedores a instalar, utilizar e estender o pacote com rapidez.
+
+## Sumário
+
+- [Visão de Arquitetura](architecture.md)
+- [Instalação e Configuração](installation.md)
+- [Guia de Uso Rápido](usage.md)
+- [Manual do Desenvolvedor](developer.md)
+- [Referência de API](api_reference.md)
+- [Configurações Avançadas](advanced_config.md)
+- [Casos de Uso e Exemplos](examples.md)
+- [Testes & Qualidade](testing.md)
+- [Desempenho e Escalabilidade](performance.md)
+- [Segurança](security.md)
+- [Troubleshooting & FAQ](troubleshooting.md)
+- [Histórico de Versões](changelog.md)
+- [Licença](license.md)

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -1,0 +1,37 @@
+# Instalação e Configuração
+
+## Pré-requisitos
+
+- Python >= 3.8
+- Dependências de sistema: pacotes de desenvolvimento do Python e bibliotecas padrões.
+- Variáveis de ambiente opcionais:
+  - `LOG_DIR` para definir o diretório padrão de logs.
+
+## Instalação via `pip`
+
+```bash
+pip install logger
+```
+
+Para ambiente de desenvolvimento:
+
+```bash
+pip install -e .[dev]
+```
+
+Se desejar reproduzir exatamente o ambiente usado nos testes:
+
+```bash
+pip install -r requirements.lock
+```
+
+## Configuração
+
+Crie um arquivo `.env` (opcional) ou defina as variáveis de ambiente necessárias. O diretório de logs é criado automaticamente.
+
+Para gerar a documentação local via Sphinx:
+
+```bash
+pip install sphinx
+make -C docs html
+```

--- a/docs/md/license.md
+++ b/docs/md/license.md
@@ -1,0 +1,3 @@
+# Licença
+
+Este projeto está licenciado sob os termos da [MIT License](../LICENSE).

--- a/docs/md/performance.md
+++ b/docs/md/performance.md
@@ -1,0 +1,12 @@
+# Desempenho e Escalabilidade
+
+O logger possui suporte a profiling via `logger.profile` e `profile_report`, permitindo identificar gargalos.
+
+Para habilitar profiling manualmente:
+
+```python
+with logger.profile_cm("Bloco"):
+    executar()
+```
+
+Também é possível monitorar CPU e memória com `log_system_status`.

--- a/docs/md/security.md
+++ b/docs/md/security.md
@@ -1,0 +1,5 @@
+# Segurança
+
+- Uso de dependências verificadas com `safety`.
+- Evite armazenar dados sensíveis nos logs.
+- Para produção, garanta permissões corretas nos arquivos de log.

--- a/docs/md/testing.md
+++ b/docs/md/testing.md
@@ -1,0 +1,16 @@
+# Testes & Qualidade
+
+Execute a suíte de testes com cobertura:
+
+```bash
+pytest --cov=logger
+```
+
+Ferramentas adicionais:
+
+```bash
+ruff check .
+mypy .
+bandit -r logger
+safety check -r requirements.lock || true
+```

--- a/docs/md/troubleshooting.md
+++ b/docs/md/troubleshooting.md
@@ -1,0 +1,10 @@
+# Troubleshooting & FAQ
+
+| Mensagem de Log | Possível Solução |
+|-----------------|------------------|
+| `Sem conexão com a internet` | Verifique o proxy ou conexão local |
+| `Falha ao capturar screenshot` | Confirme se o `pyautogui` está instalado |
+
+**FAQ**
+
+- *Como desativar a captura de prints?* Use `logger.capture_prints(False)`.

--- a/docs/md/usage.md
+++ b/docs/md/usage.md
@@ -1,0 +1,15 @@
+# Guia de Uso Rápido
+
+```python
+from logger import start_logger
+
+logger = start_logger("Demo")
+logger.info("Processo iniciado")
+
+for i in logger.progress(range(5), desc="Trabalhando"):
+    logger.debug(f"Passo {i}")
+
+logger.end()
+```
+
+A função `start_logger` retorna um objeto `Logger` já configurado com cores, níveis personalizados e handlers de arquivo. Ao final da execução, `logger.end()` é chamado automaticamente, exibindo um banner de resumo.


### PR DESCRIPTION
## Summary
- add Markdown-based documentation under docs/md/
- simplify README with links to docs

## Testing
- `ruff check .`
- `mypy .`
- `pytest --cov=logger`
- `bandit -r logger`
- `safety check -r requirements.lock`

------
https://chatgpt.com/codex/tasks/task_e_6857393864208333a6fca0b096c48771