### PR TITLE
Adicionar documentação em Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,39 @@
 
 ![CI](https://github.com/Elian-Abrao/Logger/actions/workflows/ci.yml/badge.svg)
 
-Biblioteca de logging estruturado. Veja `main.py` para um exemplo completo.
+Biblioteca em Python para logging estruturado com métricas, profiling e barra de progresso.
+
+## Sumário
+- [Visão Geral](#visão-geral)
+- [Instalação](#instalação)
+- [Uso Básico](#uso-básico)
+- [Documentação](#documentação)
+- [Contribuição](#contribuição)
+
+## Visão Geral
+O pacote oferece uma forma simples de iniciar um `logging.Logger` enriquecido com:
+- Formatação colorida com emojis
+- Logs de arquivo e console separados
+- Monitoração de CPU/Memória e detecção de vazamentos
+- Funções utilitárias como `timer`, `progress` e captura de prints
+
+### Diagrama Resumido
+```mermaid
+graph TD
+    App --> L[start_logger]
+    L --> H[Handlers]
+    H --> Console
+    H --> Arquivos
+    L --> Extras
+```
 
 ## Instalação
-
-Com o Python instalado, instale o pacote e suas dependências em modo de
-desenvolvimento:
-
 ```bash
 pip install -e .[dev]
 ```
+Ou utilize `requirements.lock` para reproduzir o ambiente.
 
-## Uso básico
-
-Crie uma instância do logger chamando `start_logger`:
-
+## Uso Básico
 ```python
 from logger import start_logger
 
@@ -24,61 +42,11 @@ logger = start_logger("Demo")
 logger.info("Processo iniciado")
 ```
 
-O método ``logger.end()`` é chamado automaticamente ao término do programa, mas pode ser invocado manualmente caso deseje encerrar o logger antecipadamente. Ao finalizar, um banner de resumo exibe métricas.
-O detalhamento completo do profiling, com cadeia de chamadas e tempos, é registrado apenas nos arquivos de log.
-
-
-Para mais exemplos consulte `main.py`.
-
-## Testes e qualidade de código
-
-Instale as dependências do projeto com:
-
-```bash
-pip install -e .[dev]
-```
-
-Para reproduzir exatamente o ambiente utilizado, instale a partir do arquivo
-`requirements.lock` gerado via `pip freeze`:
-
-```bash
-pip install -r requirements.lock
-```
-
-Sempre que atualizar as dependências, execute:
-
-```bash
-pip freeze > requirements.lock
-```
-para sincronizar o arquivo de lock.
-
-Com as dependências instaladas, execute as ferramentas de verificação:
-
-```bash
-ruff check .
-mypy .
-pytest --cov=logger
-bandit -r logger
-safety check -r requirements.lock || true
-```
-
 ## Documentação
-
-A documentação completa é gerada com **Sphinx** e publicada automaticamente no
-GitHub Pages. Para gerar a versão local instale o Sphinx e execute:
-
-```bash
-pip install sphinx
-```
-
+Guias completos estão em [docs/](docs/). Para gerar a versão HTML local:
 ```bash
 make -C docs html
 ```
 
-Para gerar os pacotes de distribuição execute:
-
-```bash
-python -m build
-```
-
-Os arquivos HTML serão gerados em `docs/build/html`.
+## Contribuição
+Siga o fluxo descrito em [docs/developer_guide.md](docs/developer_guide.md).

--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -1,0 +1,12 @@
+# Configurações Avançadas
+
+`start_logger` aceita parâmetros opcionais para customizar o comportamento:
+
+| Parâmetro | Padrão | Descrição |
+|-----------|--------|-----------|
+| `verbose` | `0` | Define detalhamento do log de arquivos |
+| `capture_prints` | `True` | Redireciona chamadas `print` |
+| `show_all_leaks` | `False` | Mostra todas as diferenças na checagem de memória |
+| `watch_objects` | `None` | Tipos de objetos monitorados em vazamento |
+
+Também é possível modificar níveis de log e diretórios via argumentos.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,16 @@
+# Referência de API
+
+## logger.start_logger
+`start_logger(name, log_dir='Logs', console_level='INFO', file_level='DEBUG', capture_prints=True, verbose=0, *, show_all_leaks=False, watch_objects=None) -> logging.Logger`
+
+Cria e configura uma instância de `logging.Logger` com recursos adicionais.
+
+Principais parâmetros:
+- **name**: nome base do logger
+- **log_dir**: pasta onde os arquivos serão salvos
+- **console_level**: nível exibido no console
+- **file_level**: nível gravado nos arquivos
+
+Retorna um logger com métodos extras como `progress`, `screen`, `timer` e outros.
+
+Consulte os módulos em `logger/extras` para detalhes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,34 @@
+# Visão de Arquitetura
+
+```mermaid
+graph TD
+    App[Aplicação] -->|usa| Start(start_logger)
+    Start --> Logger
+    Logger --> Console[Console/CLI]
+    Logger --> Files[Arquivos de Log]
+    Logger --> Extras
+    Extras --> Metrics[Métricas]
+    Extras --> Monitoring[Monitoramento]
+    Extras --> Network[Conectividade]
+```
+
+```mermaid
+sequenceDiagram
+    participant U as Usuário
+    participant A as Aplicação
+    participant L as Logger
+    participant C as Console
+    participant F as Arquivos
+
+    U->>A: executa script
+    A->>L: start_logger()
+    L->>C: banner inicial
+    loop processamento
+        A->>L: info/debug...
+        L->>F: salva log
+        L->>C: imprime saída
+    end
+    A->>L: end()
+    L->>C: banner final
+    L->>F: fecha arquivos
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## [0.1.0] - Versão inicial
+- Estrutura básica do pacote
+- Handlers e formatadores customizados
+- Módulo de métricas e monitoramento

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,25 @@
+# Manual do Desenvolvedor
+
+## Estrutura de Pastas
+```
+logger/
+  core/        # núcleo de configuração
+  extras/      # funcionalidades auxiliares
+  handlers/    # handlers customizados
+  formatters/  # formatadores de log
+  tests/       # suíte de testes
+```
+
+## Convenções
+- Código formatado com **black** e verificado por **ruff**
+- Tipagem estática com **mypy**
+- Utilize emojis nos logs para facilitar a leitura 😄
+- Barras de progresso opcionais via `logger.progress`
+
+## Fluxo de Contribuição
+1. Crie uma branch a partir de `main`
+2. Escreva testes para novas features
+3. Execute `ruff`, `mypy` e `pytest`
+4. Abra um Pull Request descrevendo a mudança
+
+Política de versionamento: **SemVer** seguindo `pyproject.toml`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,13 @@
+# Casos de Uso e Exemplos
+
+## Timer
+```python
+with logger.timer("Carga de dados"):
+    carregar_dados()
+```
+
+## Captura de prints
+```python
+with logger.capture_prints(logger, level="WARNING"):
+    print("não use prints! :) ")
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,20 @@
+# Guia de Instalação e Configuração
+
+## Pré-requisitos
+- Python >= 3.8
+- Dependências do sistema listadas em `pyproject.toml`
+
+## Instalação
+```bash
+pip install -e .[dev]
+```
+
+Ou para o ambiente exato usado pelo projeto:
+```bash
+pip install -r requirements.lock
+```
+
+## Configuração
+A biblioteca não requer variáveis de ambiente específicas. Os logs são
+salvos em `Logs/` por padrão, podendo ser alterado com o parâmetro
+`log_dir` de `start_logger`.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,5 @@
+# Desempenho e Escalabilidade
+
+- O monitoramento de CPU e memória utiliza **psutil**
+- Para profiling detalhado, use `logger.profile` ou `logger.profile_cm`
+- Potenciais gargalos estão na escrita em disco e captura de screenshots

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,16 @@
+# Guia de Uso Rápido
+
+Crie um logger minimalista:
+```python
+from logger import start_logger
+
+logger = start_logger("Demo")
+logger.info("Processo iniciado")
+```
+
+O método `logger.end()` é acionado automaticamente ao finalizar o
+programa. Para progress bar integrada:
+```python
+for i in logger.progress(range(5), desc="Trabalhando"):
+    logger.debug(f"Passo {i}")
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,5 @@
+# Segurança
+
+- Evite expor arquivos de log contendo dados sensíveis
+- Dependências checadas via `safety`
+- Utilize ambientes virtuais para isolamento

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,13 @@
+# Testes e Qualidade
+
+Execute a suíte completa:
+```bash
+pytest --cov=logger
+```
+
+Ferramentas adicionais:
+```bash
+ruff check .
+mypy .
+bandit -r logger
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,10 @@
+# Troubleshooting & FAQ
+
+| Erro/Mensagem | Possível Solução |
+|---------------|-----------------|
+| `ModuleNotFoundError` | Verifique instalação das dependências |
+| `Permission denied` ao gravar log | Confirme permissões da pasta `log_dir` |
+
+**Perguntas frequentes**
+- *Como alterar o diretório de logs?* Use o parâmetro `log_dir` em `start_logger`.
+- *Como desativar a captura de prints?* Passe `capture_prints=False`.


### PR DESCRIPTION
## Descrição
- inclusão de diversos documentos em `docs/`
- atualização do `README.md` com visão geral e links

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857393864208333a6fca0b096c48771