### PR TITLE
Allow optional profiling output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ from logger import start_logger
 logger = start_logger("Demo")
 logger.info("Processo iniciado")
 ```
+Use `show_profiling=True` em `start_logger` para exibir o resumo de
+profiling no encerramento.
 
 ## Documentação
 Guias completos estão em [docs/](docs/). Para gerar a versão HTML local:

--- a/logger/__init__.pyi
+++ b/logger/__init__.pyi
@@ -53,11 +53,11 @@ class StructuredLogger(Logger):
 
     def capture_prints(self, active: bool = True, level: str = "INFO", prefix: str = ...) -> None: ...
 
-    def start(self, verbose: int = 1) -> None:
+    def start(self, verbose: int = 1, *, show_profiling: bool | None = None) -> None:
         """Exibe informações de início de execução."""
         ...
 
-    def end(self, verbose: int = 1) -> None:
+    def end(self, verbose: int = 1, *, show_profiling: bool | None = None) -> None:
         """Exibe informações de encerramento de execução."""
         ...
 
@@ -142,6 +142,7 @@ def start_logger(
     capture_prints: bool = True,
     verbose: int = 0,
     *,
+    show_profiling: bool = False,
     show_all_leaks: bool = False,
     watch_objects: Iterable[str] | None = None,
 ) -> StructuredLogger:

--- a/logger/core/logger_core.py
+++ b/logger/core/logger_core.py
@@ -51,6 +51,7 @@ def start_logger(
     capture_prints: bool = True,
     verbose: int = 0,
     *,
+    show_profiling: bool = False,
     show_all_leaks: bool = False,
     watch_objects: Iterable[str] | None = None,
 ) -> Logger:
@@ -71,6 +72,9 @@ def start_logger(
     watch_objects:
         Lista de tipos de objetos para acompanhar sempre na verificação de
         vazamento de memória.
+
+    show_profiling:
+        Define se o resumo de profiling será exibido ao final da execução.
     """
     logger = _configure_base_logger(
         name, log_dir, console_level, file_level, verbose
@@ -80,13 +84,14 @@ def start_logger(
     _setup_context_and_profiling(logger)
     _setup_dependencies_and_network(logger)
     _setup_lifecycle(logger)
+    setattr(logger, "_show_profiling", show_profiling)
     setattr(logger, "_leak_show_all", show_all_leaks)
     setattr(logger, "_leak_watch", set(watch_objects or []))
     setattr(logger, "_leak_threshold_mb", 5.0)
     if capture_prints:
         logger.capture_prints(True)  # type: ignore[attr-defined]
     logger.memory_snapshot()  # type: ignore[attr-defined]
-    logger.start()  # type: ignore[attr-defined]
+    logger.start(show_profiling=show_profiling)  # type: ignore[attr-defined]
     return logger
 
 

--- a/logger/tests/test_basic.py
+++ b/logger/tests/test_basic.py
@@ -1,6 +1,7 @@
 """Testes unitários para o pacote ``logger``"""
 
 from pathlib import Path
+import logging
 
 from logger import start_logger
 
@@ -36,3 +37,17 @@ def test_progress_bar_usage(tmp_path):
     assert getattr(logger, "_active_pbar", None) is None
 
     logger.end()
+
+
+def test_profiling_hidden_by_default(tmp_path, caplog):
+    logger = start_logger('prof0', log_dir=str(tmp_path), console_level='INFO')
+    with caplog.at_level(logging.INFO):
+        logger.end()
+    assert not any('PROFILING' in r.message for r in caplog.records)
+
+
+def test_profiling_enabled(tmp_path, caplog):
+    logger = start_logger('prof1', log_dir=str(tmp_path), console_level='INFO', show_profiling=True)
+    with caplog.at_level(logging.INFO):
+        logger.end()
+    assert any('PROFILING' in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow disabling profiling by default
- add `show_profiling` parameter to `start_logger`
- persist profiling preference in lifecycle helpers
- document profiling option in README
- test profiling console toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711b2277b08333bb8a1e787e6484c9